### PR TITLE
[Fix] Allow filtering optional db model fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ This package is for you if you're building data-driven applications and you're u
 
 If you're tired of writing raw SQL for querying Azure CosmosDB NoSQL database with complex filters, then this package is for you, too.
 
+<p align="center">
+  <img src="docs/demo.gif" />
+  The code above gives you query auto-completion based on the data model you specified for each container in Azure CosmosDB
+</p>
+
 ## 🤔 Use cases:
 
 - Data analytics dashboard

--- a/README.md
+++ b/README.md
@@ -199,4 +199,4 @@ const result = orm.user.delete({
 - ~~Core Query builder~~
 - Bulk create / update operations
 - Observability - query logging
-- Filtering complex data types such as string arrays & number arrays
+- Filtering on more complex data types such as enums, enum arrays, string arrays & number arrays

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosmox",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "cosmosdb",
     "prisma",

--- a/src/services/cosmos-db.service.ts
+++ b/src/services/cosmos-db.service.ts
@@ -285,13 +285,13 @@ const defaultFields: AutoFields = {
 
 /** Utility type to define where clause filters */
 export type Where<T extends Base> = {
-  [K in keyof T]?: T[K] extends string
+  [K in keyof T]?: T[K] extends string | undefined
     ? StringFilter
-    : T[K] extends number
+    : T[K] extends number | undefined
       ? NumberFilter
-      : T[K] extends boolean
+      : T[K] extends boolean | undefined
         ? BooleanFilter
-        : T[K] extends Date
+        : T[K] extends Date | undefined
           ? DateFilter
           : never;
 };
@@ -340,7 +340,9 @@ export class BaseModel<T extends Base = typeof initial> {
   }
 
   /** Find many items with pagination and type-safe filters */
-  public async findMany(args: FindManyArgs<T>): Promise<FindManyResponse<T>> {
+  public async findMany(
+    args: FindManyArgs<Required<T>>,
+  ): Promise<FindManyResponse<T>> {
     const { take, nextCursor } = args;
 
     // validate "take" if provided by user


### PR DESCRIPTION
## Changes
1. Enable query auto-completion for non-required fields from db model
```typescript
type User = {
  firstName?: string; // when a field is optional
  lastName?: string; // when a field is optional
};

// before
orm.user.findMany({
  // no auto-completion, IDE is not throwing errors for typos. Shoud've been "firstName"
  where: { firstname: "James" },
})

// after
orm.user.findMany({
  // has auto-completion, IDE is throwing errors for typos, only "firstName" is allowed
  where: { firstName: "James" },
})
```
3. Docs update, added gif as demo
4. Bumped pkg version to `1.0.1`, prep for next release