### PR TITLE
Fix module resolution issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,18 +24,18 @@
     "dev": "tsup src/index.ts --watch",
     "prepare": "husky"
   },
-  "main": "./dist/index.mjs",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
       }
     }
   },


### PR DESCRIPTION
It seems that, when the package is actually distributed, instead of using `mts`/`mjs` filenames for module-style JS and `ts`/`js` filenames for common-style JS, it instead uses `ts`/`js` filenames for module-style JS and `cts`/`cts` filenames for common-style JS.

This does not line up with the contents of `package.json`, making module resolution fail.

This PR adjusts `package.json` to line up with the actual files that get distributed, making module resolution work again.