### PR TITLE
Don't error when findMany results in undefined

### DIFF
--- a/src/services/cosmos-db.service.ts
+++ b/src/services/cosmos-db.service.ts
@@ -377,13 +377,19 @@ export class BaseModel<T extends Base = typeof initial> {
       throw new Error(message);
     }
 
-    let { resources, continuationToken } = result.value;
-    if (isArray<T>(resources) === false) {
-      if (resources === undefined) resources = [] as unknown as T[];
-      else {
-        const message = `Retrieved data from db, but received ${typeof resources} instead of a list of items`;
-        throw new Error(message);
-      }
+    const { resources, continuationToken } = result.value;
+
+    if (isUndefined(resources)) {
+      const response: FindManyResponse<T> = {
+        items: [],
+        nextCursor: continuationToken,
+      };
+      return response;
+    }
+
+    if (!isArray(resources)) {
+      const message = `Retrieved data from db, but received "${typeof resources}" instead of a list of items`;
+      throw new Error(message);
     }
 
     const response: FindManyResponse<T> = {

--- a/src/services/cosmos-db.service.ts
+++ b/src/services/cosmos-db.service.ts
@@ -377,10 +377,13 @@ export class BaseModel<T extends Base = typeof initial> {
       throw new Error(message);
     }
 
-    const { resources, continuationToken } = result.value;
+    let { resources, continuationToken } = result.value;
     if (isArray<T>(resources) === false) {
-      const message = `Retrieved data from db, but received ${typeof resources} instead of a list of items`;
-      throw new Error(message);
+      if (resources === undefined) resources = [] as unknown as T[];
+      else {
+        const message = `Retrieved data from db, but received ${typeof resources} instead of a list of items`;
+        throw new Error(message);
+      }
     }
 
     const response: FindManyResponse<T> = {


### PR DESCRIPTION
I'm not sure if this happens with the actual Azure Cosmos DB service, but the Azure Cosmos DB Emulator will return `undefined` as `resources` if it didn't find anything, *not* an empty array.

This quick fix accounts for that and, if `resources === undefined`, replaces `resources` with an empty array.

(This isn't exactly tested... I corrected it in the transpiled JS with `bun patch` in my project to work around it for now, and that works, but I didn't test if the TypeScript is actually correct.)