### PR TITLE
fix: update packageManager version and improve contributor instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,9 @@ The following steps will get you setup to contribute changes to this repo:
 
 2. Clone your forked repo
 
-3. Make sure you have the matching version of `pnpm` installed by running `pnpm --version`. Currently, we're on `9.8.10`
+3. Run `pnpm install` to install dependencies.
 
-4. Run `pnpm` to install dependencies.
-
-5. Start playing with the code! You can do some simple experimentation in your own project or start implementing a feature right away.
+4. Start playing with the code! You can do some simple experimentation in your own project or start implementing a feature right away.
 
 ### Commands
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       }
     }
   },
-  "packageManager": "pnpm@9.8.10",
+  "packageManager": "pnpm@9.8.0",
   "dependencies": {
     "@azure/cosmos": "4.2.0",
     "neverthrow": "8.1.1",


### PR DESCRIPTION
Replaces invalid `"pnpm@9.8.10"` with `"pnpm@9.8.0"` in `package.json`, as the originally referenced version does not exist on the npm registry.

Also simplifies `CONTRIBUTING.md`:
- Removes the unnecessary version check
- Replaces `pnpm` with `pnpm install`, since `pnpm` alone does not install dependencies and may open the help output instead

Fixes #12